### PR TITLE
Drop handler "readiness" field

### DIFF
--- a/sunbeam_migrate/cmd/capabilities.py
+++ b/sunbeam_migrate/cmd/capabilities.py
@@ -34,7 +34,6 @@ def _show_all_migration_handlers():
         "Member resource types",
         "Associated resource types",
         "Batch resource filters",
-        "Ready",
     ]
     table.sortby = "Service"
     for resource_type, handler in factory.get_all_handlers().items():
@@ -45,7 +44,6 @@ def _show_all_migration_handlers():
                 _user_friendly_list(handler.get_member_resource_types()),
                 _user_friendly_list(handler.get_associated_resource_types()),
                 _user_friendly_list(handler.get_supported_resource_filters()),
-                handler.get_implementation_status(),
             ]
         )
     print(table)
@@ -76,5 +74,4 @@ def _show_migration_handler(resource_type: str):
             _user_friendly_list(handler.get_supported_resource_filters()),
         ]
     )
-    table.add_row(["Readiness", handler.get_implementation_status()])
     print(table)

--- a/sunbeam_migrate/constants.py
+++ b/sunbeam_migrate/constants.py
@@ -5,9 +5,3 @@ STATUS_IN_PROGRESS = "in-progress"
 STATUS_COMPLETED = "completed"
 STATUS_FAILED = "failed"
 STATUS_SOURCE_CLEANUP_FAILED = "source-cleanup-failed"
-
-# Constants that describe the implementation readiness
-# of each migration handler.
-IMPL_PLACEHOLDER = "no-op"
-IMPL_PARTIAL = "partial"
-IMPL_FULL = "full"

--- a/sunbeam_migrate/handlers/barbican/secret.py
+++ b/sunbeam_migrate/handlers/barbican/secret.py
@@ -3,7 +3,7 @@
 
 import base64
 
-from sunbeam_migrate import config, constants, exception
+from sunbeam_migrate import config, exception
 from sunbeam_migrate.handlers import base
 from sunbeam_migrate.utils import barbican_utils
 
@@ -23,10 +23,6 @@ class SecretHandler(base.BaseMigrationHandler):
         These filters can be specified when initiating batch migrations.
         """
         return ["owner_id"]
-
-    def get_implementation_status(self) -> str:
-        """Describe the implementation status."""
-        return constants.IMPL_PARTIAL
 
     def perform_individual_migration(
         self,

--- a/sunbeam_migrate/handlers/barbican/secret_container.py
+++ b/sunbeam_migrate/handlers/barbican/secret_container.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 - Canonical Ltd
 # SPDX-License-Identifier: Apache-2.0
 
-from sunbeam_migrate import config, constants, exception
+from sunbeam_migrate import config, exception
 from sunbeam_migrate.handlers import base
 from sunbeam_migrate.utils import barbican_utils
 
@@ -21,10 +21,6 @@ class SecretContainerHandler(base.BaseMigrationHandler):
         These filters can be specified when initiating batch migrations.
         """
         return ["owner_id"]
-
-    def get_implementation_status(self) -> str:
-        """Describe the implementation status."""
-        return constants.IMPL_PARTIAL
 
     def get_associated_resource_types(self) -> list[str]:
         """Get a list of associated resource types."""

--- a/sunbeam_migrate/handlers/base.py
+++ b/sunbeam_migrate/handlers/base.py
@@ -7,7 +7,7 @@ import os
 import openstack
 from openstack import exceptions as openstack_exc
 
-from sunbeam_migrate import config, constants, exception
+from sunbeam_migrate import config, exception
 
 CONF = config.get_config()
 
@@ -108,10 +108,6 @@ class BaseMigrationHandler(abc.ABC):
         These filters can be specified when initiating batch migrations.
         """
         return []
-
-    def get_implementation_status(self) -> str:
-        """Describe the implementation status."""
-        return constants.IMPL_PLACEHOLDER
 
     def _get_openstack_session(self, cloud_name: str):
         if not CONF.cloud_config_file:

--- a/sunbeam_migrate/handlers/glance/image.py
+++ b/sunbeam_migrate/handlers/glance/image.py
@@ -3,7 +3,7 @@
 
 import hashlib
 
-from sunbeam_migrate import config, constants, exception
+from sunbeam_migrate import config, exception
 from sunbeam_migrate.handlers import base
 
 CONF = config.get_config()
@@ -22,10 +22,6 @@ class ImageHandler(base.BaseMigrationHandler):
         These filters can be specified when initiating batch migrations.
         """
         return ["owner_id"]
-
-    def get_implementation_status(self) -> str:
-        """Describe the implementation status."""
-        return constants.IMPL_PARTIAL
 
     def perform_individual_migration(
         self,

--- a/sunbeam_migrate/handlers/neutron/network.py
+++ b/sunbeam_migrate/handlers/neutron/network.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 - Canonical Ltd
 # SPDX-License-Identifier: Apache-2.0
 
-from sunbeam_migrate import config, constants, exception
+from sunbeam_migrate import config, exception
 from sunbeam_migrate.handlers import base
 
 CONF = config.get_config()
@@ -20,10 +20,6 @@ class NetworkHandler(base.BaseMigrationHandler):
         These filters can be specified when initiating batch migrations.
         """
         return ["owner_id"]
-
-    def get_implementation_status(self) -> str:
-        """Describe the implementation status."""
-        return constants.IMPL_PARTIAL
 
     def get_associated_resource_types(self) -> list[str]:
         """Get a list of associated resource types.

--- a/sunbeam_migrate/handlers/neutron/security_group.py
+++ b/sunbeam_migrate/handlers/neutron/security_group.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 - Canonical Ltd
 # SPDX-License-Identifier: Apache-2.0
 
-from sunbeam_migrate import config, constants, exception
+from sunbeam_migrate import config, exception
 from sunbeam_migrate.handlers import base
 
 CONF = config.get_config()
@@ -27,10 +27,6 @@ class SecurityGroupHandler(base.BaseMigrationHandler):
         Associated resources must be migrated first.
         """
         return []
-
-    def get_implementation_status(self) -> str:
-        """Describe the implementation status."""
-        return constants.IMPL_PARTIAL
 
     def get_associated_resources(self, resource_id: str) -> list[tuple[str, str]]:
         """Security groups have no prerequisite resources."""

--- a/sunbeam_migrate/handlers/neutron/security_group_rule.py
+++ b/sunbeam_migrate/handlers/neutron/security_group_rule.py
@@ -6,7 +6,7 @@ import re
 
 from openstack import exceptions as openstack_exc
 
-from sunbeam_migrate import config, constants, exception
+from sunbeam_migrate import config, exception
 from sunbeam_migrate.handlers import base
 
 CONF = config.get_config()
@@ -26,10 +26,6 @@ class SecurityGroupRuleHandler(base.BaseMigrationHandler):
         These filters can be specified when initiating batch migrations.
         """
         return ["owner_id"]
-
-    def get_implementation_status(self) -> str:
-        """Describe the implementation status."""
-        return constants.IMPL_PARTIAL
 
     def get_associated_resource_types(self) -> list[str]:
         """Security group rules depend on their security group."""

--- a/sunbeam_migrate/handlers/neutron/subnet.py
+++ b/sunbeam_migrate/handlers/neutron/subnet.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 - Canonical Ltd
 # SPDX-License-Identifier: Apache-2.0
 
-from sunbeam_migrate import config, constants, exception
+from sunbeam_migrate import config, exception
 from sunbeam_migrate.handlers import base
 
 CONF = config.get_config()
@@ -20,10 +20,6 @@ class SubnetHandler(base.BaseMigrationHandler):
         These filters can be specified when initiating batch migrations.
         """
         return ["owner_id"]
-
-    def get_implementation_status(self) -> str:
-        """Describe the implementation status."""
-        return constants.IMPL_PARTIAL
 
     def get_associated_resource_types(self) -> list[str]:
         """Get a list of associated resource types.


### PR DESCRIPTION
We no longer need placeholder migration handlers. Missing features can be documented using inline TODOs, log notes/warnings or readme sections.