### PR TITLE
Update readme, dropping 'ready' field

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,19 +46,19 @@ Get migration handler capabilities:
 
 ```
 $ sunbeam-migrate capabilities
-+-----------------------------------------------------------------------------------------------------------------------+
-|                                                   Migration handlers                                                  |
-+----------+---------------------+-----------------------+---------------------------+------------------------+---------+
-| Service  |    Resource type    | Member resource types | Associated resource types | Batch resource filters |  Ready  |
-+----------+---------------------+-----------------------+---------------------------+------------------------+---------+
-| Barbican |        secret       |           -           |             -             |        owner_id        | partial |
-| Barbican |   secret-container  |           -           |           secret          |        owner_id        | partial |
-|  Glance  |        image        |           -           |             -             |        owner_id        | partial |
-| Neutron  |       network       |         subnet        |             -             |        owner_id        | partial |
-| Neutron  |    security-group   |  security-group-rule  |             -             |        owner_id        | partial |
-| Neutron  | security-group-rule |           -           |       security-group      |        owner_id        | partial |
-| Neutron  |        subnet       |           -           |          network          |        owner_id        | partial |
-+----------+---------------------+-----------------------+---------------------------+------------------------+---------+
++-------------------------------------------------------------------------------------------------------------+
+|                                              Migration handlers                                             |
++----------+---------------------+-----------------------+---------------------------+------------------------+
+| Service  |    Resource type    | Member resource types | Associated resource types | Batch resource filters |
++----------+---------------------+-----------------------+---------------------------+------------------------+
+| Barbican |        secret       |           -           |             -             |        owner_id        |
+| Barbican |   secret-container  |           -           |           secret          |        owner_id        |
+|  Glance  |        image        |           -           |             -             |        owner_id        |
+| Neutron  |       network       |         subnet        |             -             |        owner_id        |
+| Neutron  |    security-group   |  security-group-rule  |             -             |        owner_id        |
+| Neutron  | security-group-rule |           -           |       security-group      |        owner_id        |
+| Neutron  |        subnet       |           -           |          network          |        owner_id        |
++----------+---------------------+-----------------------+---------------------------+------------------------+
 
 $ sunbeam-migrate capabilities --resource-type=subnet
 +--------------------------------------+


### PR DESCRIPTION
The readiness field was removed from the list of capabilities. Let's update the readme.