### PR TITLE
Drop unnecessary argument and update docstring

### DIFF
--- a/sunbeam_migrate/handlers/base.py
+++ b/sunbeam_migrate/handlers/base.py
@@ -114,7 +114,6 @@ class BaseMigrationHandler(abc.ABC):
 
     def connect_member_resources_to_parent(
         self,
-        parent_resource_type: str,
         parent_resource_id: str | None,
         migrated_member_resources: list[tuple[str, str, str]],
     ):
@@ -122,7 +121,8 @@ class BaseMigrationHandler(abc.ABC):
 
         This is called after member resources have been migrated.
 
-        :param parent_resource_id: The destination ID of the parent resource.
+        :param parent_resource_id: The destination ID of the parent resource,
+                                   having the same type as that of the handler.
         :param migrated_member_resources: A list of tuples describing
             member resources that have been migrated.
             Format: (resource_type, source_id, destination_id)

--- a/sunbeam_migrate/handlers/neutron/router.py
+++ b/sunbeam_migrate/handlers/neutron/router.py
@@ -145,7 +145,6 @@ class RouterHandler(base.BaseMigrationHandler):
 
     def connect_member_resources_to_parent(
         self,
-        parent_resource_type: str,
         parent_resource_id: str | None,
         migrated_member_resources: list[tuple[str, str, str]],
     ):
@@ -155,9 +154,6 @@ class RouterHandler(base.BaseMigrationHandler):
             member_source_id,
             dest_subnet_id,
         ) in migrated_member_resources:
-            if resource_type != "subnet":
-                continue
-
             LOG.info(
                 "Attaching internal subnet %s (dest %s) to router %s",
                 member_source_id,

--- a/sunbeam_migrate/manager.py
+++ b/sunbeam_migrate/manager.py
@@ -53,7 +53,6 @@ class SunbeamMigrationManager:
             )
             try:
                 handler.connect_member_resources_to_parent(
-                    parent_resource_type="",
                     parent_resource_id=migration.destination_id,
                     migrated_member_resources=migrated_member_resources,
                 )


### PR DESCRIPTION
Since the resource type received by "connect_member_resources_to_parent" matches that of the migration handler, we can go ahead and drop it.