### PR TITLE
docs: add a page describing multi-tenant mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,24 +181,6 @@ The migration process:
 5. **Creates health monitors** for pools that have them
 6. **Creates members** in each pool with their subnet mappings
 
-## Multi-tenant mode
-
-`sunbeam-migrate` allows migrating resources owned by other projects (tenants)
-and preserving the owner information. This requires admin privileges.
-
-The `multitenant_mode` setting is enabled by default. As a result, the owner
-project and user resources are reported as dependencies and migrated
-automatically.
-
-Not all Openstack services allow specifying a different owner when creating
-resources. As such, `sunbeam-migrate` needs to use project scoped sessions,
-assigning itself as a member of the migrated tenant.
-
-At the moment, this feature does not support Nova keypairs and Barbican secrets.
-The keypairs will be skipped when migrating instances if the multi-tenant mode
-is enabled. However, the keypair information shouldn't be mandatory for
-already provisioned instances.
-
 
 ## Potential future improvements
 

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -168,6 +168,8 @@ initiator
 intra
 isolCPUs
 juju
+keypair
+keypairs
 kube
 kubeconfig
 kubectl

--- a/docs/explanation/index.rst
+++ b/docs/explanation/index.rst
@@ -8,3 +8,4 @@ Index
    :maxdepth: 1
 
    architecture
+   multitenant-mode

--- a/docs/explanation/multitenant-mode.rst
+++ b/docs/explanation/multitenant-mode.rst
@@ -1,0 +1,18 @@
+Multi-tenant mode
+-----------------
+
+``sunbeam-migrate`` allows migrating resources owned by other projects (tenants)
+and preserving the owner information. This requires admin privileges.
+
+The ``multitenant_mode`` setting is enabled by default. As a result, the owner
+project and user resources are reported as dependencies and migrated
+automatically.
+
+Not all Openstack services allow specifying a different owner when creating
+resources. As such, ``sunbeam-migrate`` needs to use project scoped sessions,
+assigning itself as a member of the migrated tenant.
+
+At the moment, this feature does not support Nova keypairs and Barbican secrets.
+The keypairs will be skipped when migrating instances if the multi-tenant mode
+is enabled. However, the keypair information shouldn't be mandatory for
+already provisioned instances.

--- a/docs/tutorial/get-started-with-sunbeam-migrate.rst
+++ b/docs/tutorial/get-started-with-sunbeam-migrate.rst
@@ -229,7 +229,7 @@ a given migration like so:
 
 .. code-block:: none
 
-	$ sunbeam-migrate show 0209b968-10ae-4770-ac6e-6c454fb4323f
+	sunbeam-migrate show 0209b968-10ae-4770-ac6e-6c454fb4323f
 
 	+----------------------------------------------------------+
 	|                        Migration                         |
@@ -267,7 +267,7 @@ Use the ``cleanup-source`` command like so:
 
 .. code-block:: none
 
-	$ sunbeam-migrate cleanup-source --resource-type=image
+	sunbeam-migrate cleanup-source --resource-type=image
 
 	2025-12-16 14:33:32,897 INFO Migration succeeded, cleaning up source image: 5f7f24cc-b700-4195-80af-50e61adff91d
 	2025-12-16 14:33:34,575 INFO Migration succeeded, cleaning up source image: 19da365c-ddb4-432c-92f2-60b966d347fe
@@ -279,7 +279,7 @@ that it also allows filtering by resource id or service type.
 
 .. code-block:: none
 
-	$ sunbeam-migrate cleanup-source -h
+	sunbeam-migrate cleanup-source -h
 
 	Usage: sunbeam-migrate cleanup-source [OPTIONS]
 
@@ -299,11 +299,11 @@ Migration handlers
 ------------------
 
 Run the following command to see the list of migration handlers and how they
-define resource relations: 
+define resource relations:
 
 .. code-block:: none
 
-	$ sunbeam-migrate capabilities
+	sunbeam-migrate capabilities
 
 	+------------------------------------------------------------------------------------------------------------------------------------------+
 	|                                                            Migration handlers                                                            |


### PR DESCRIPTION
We're moving the multi-tenant documentation to a separate docs page, part of the "explanation" section.