### PR TITLE
Add explanation page on Vault Secret Migration

### DIFF
--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -32,6 +32,8 @@ JSON
 Juju
 Kubeflow
 Kubernetes
+kv
+KV
 Launchpad
 linter
 LTS
@@ -40,6 +42,7 @@ lxdbr
 Makefile
 Matrix
 Mattermost
+mypasswords
 MyST
 namespace
 namespaces

--- a/docs/explanation/index.rst
+++ b/docs/explanation/index.rst
@@ -9,3 +9,4 @@ Index
 
    architecture
    multitenant-mode
+   vault-secret-migration

--- a/docs/explanation/vault-secret-migration.rst
+++ b/docs/explanation/vault-secret-migration.rst
@@ -1,0 +1,283 @@
+Vault Secret Migration
+======================
+
+Barbican Secrets
+----------------
+This guide refers specifically to migrating secrets stored in Vault between two different deployments: the source Vault used by Charmed Openstack and the destination Vault deployed as vault-k8s within Sunbeam. The Barbican secrets migration process is separate and those secrets are handled by the `sunbeam-migrate` tool, with the Barbican secrets migration handler.
+
+Overview
+--------
+
+This guide explains how to migrate secrets between two Vault deployments (Charmed Openstack and Sunbeam) using the Vault CLI and custom scripts. 
+
+The migration process involves:
+
+1. Configuring access to the source Vault (from Charmed Openstack)
+2. Configuring access to the destination Vault (vault-k8s from Sunbeam)
+3. Exporting secrets from the source Vault
+4. Importing secrets into the destination Vault
+
+Prerequisites
+-------------
+
+Ensure you have the following tools installed:
+
+* ``vault`` CLI (Vault client)
+* ``jq`` (JSON processor)
+* ``yq`` (YAML processor)
+
+Source Vault Configuration (Machine Charm)
+-------------------------------------------
+
+The source Vault is deployed as a Juju machine charm. Follow these steps to configure access:
+
+Step 1: Set the Vault Address
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Get the public address of the Vault leader unit and set the ``VAULT_ADDR`` environment variable:
+
+.. code-block:: bash
+
+   export VAULT_ADDR=https://$(juju status vault/leader --format=yaml | awk '/public-address/ { print $2 }'):8200
+   echo $VAULT_ADDR
+
+Step 2: Retrieve the CA Certificate
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Vault charm uses a self-signed certificate. Retrieve it from Juju secrets:
+
+.. code-block:: bash
+
+   # Find the certificate secret ID
+   cert_juju_secret_id=$(juju secrets --format=yaml | yq 'to_entries | .[] | select(.value.label == "self-signed-vault-ca-certificate") | .key')
+   echo $cert_juju_secret_id
+
+   # Extract the certificate to a file
+   juju show-secret ${cert_juju_secret_id} --reveal --format=yaml | yq '.[].content.certificate' > vault.pem
+
+   # Set the CA certificate path
+   export VAULT_CACERT=$PWD/vault.pem
+   echo $VAULT_CACERT
+
+.. note::
+   You can use either ``VAULT_CACERT`` or ``VAULT_CAPATH``. ``VAULT_CACERT`` points to a single certificate file, while ``VAULT_CAPATH`` points to a directory containing certificates.
+
+Step 3: Enable KV v2 Secrets Engine (If Not Already Done)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Enable the KV v2 secrets engine if it's not already enabled:
+
+.. code-block:: bash
+
+   vault secrets enable -version=2 kv
+
+Verify you can read/write secrets:
+
+.. code-block:: bash
+
+   # Write a test secret
+   vault kv put kv/test password=test123
+
+   # Read it back
+   vault kv get kv/test
+
+Destination Vault Configuration (Vault-k8s from Sunbeam)
+--------------------------------------------------------
+
+The destination Vault is deployed as vault-k8s inside Sunbeam. The configuration process is similar but adapted for the Kubernetes environment.
+
+Step 1: Set the Vault Address
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Get the Vault service address from the Sunbeam cluster:
+
+.. code-block:: bash
+
+   # Get the vault-k8s unit address
+   export VAULT_ADDR="https://$(juju status --format=yaml | yq '.applications."vault-k8s".address'):8200"
+   echo $VAULT_ADDR
+
+Step 2: Retrieve the CA Certificate
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Similar to the source, retrieve the CA certificate for vault-k8s:
+
+.. code-block:: bash
+
+   # Find the certificate secret ID
+   cert_juju_secret_id=$(juju secrets --format=yaml | yq 'to_entries | .[] | select(.value.label == "self-signed-vault-ca-certificate") | .key')
+   echo $cert_juju_secret_id
+
+   # Extract the certificate
+   juju show-secret ${cert_juju_secret_id} --reveal --format=yaml | yq '.[].content.certificate' > vault-k8s.pem
+
+   # Set the CA certificate path
+   export VAULT_CACERT=$PWD/vault-k8s.pem
+
+Step 3: Enable KV v2 Secrets Engine (If Not Already Done)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Enable the KV v2 secrets engine if it's not already enabled:
+
+.. code-block:: bash
+
+   vault secrets enable -version=2 kv
+
+Verify you can read/write secrets:
+
+.. code-block:: bash
+
+   # Write a test secret
+   vault kv put kv/test password=test123
+
+   # Read it back
+   vault kv get kv/test
+
+Migration Process
+-----------------
+
+Once both Vault instances are configured, you can migrate secrets using the migration script below.
+
+The migration script handles both export from the source Vault and import to the destination Vault in a single operation. It manages the environment variables internally, switching between source and destination as needed.
+
+Using the Migration Script
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    
+The migration script is provided in the `sunbeam-migrate` repository under `misc/scripts/vault_migrate.sh <https://github.com/petrutlucian94/sunbeam-migrate/blob/main/misc/scripts/vault_migrate.sh>`_. Save the script to your local machine.
+
+.. code-block:: bash
+
+   chmod +x vault_migrate.sh
+
+Run the migration:
+
+.. code-block:: bash
+
+   # Basic usage - migrate all secrets from a mount
+   ./vault_migrate.sh \
+     --source-addr "https://10.44.77.172:8200" \
+     --source-cacert "/path/to/source-vault.pem" \
+     --source-token "hvs.source_token" \
+     --dest-addr "https://10.5.0.10:8200" \
+     --dest-cacert "/path/to/dest-vault.pem" \
+     --dest-token "hvs.dest_token" \
+     --mount "kv"
+
+   # Migrate from a specific path within a mount
+   ./vault_migrate.sh \
+     --source-addr "https://10.44.77.172:8200" \
+     --source-cacert "/path/to/source-vault.pem" \
+     --source-token "hvs.source_token" \
+     --dest-addr "https://10.5.0.10:8200" \
+     --dest-cacert "/path/to/dest-vault.pem" \
+     --dest-token "hvs.dest_token" \
+     --mount "kv" \
+     --start-path "mypasswords/"
+
+   # Dry run to verify without making changes
+   ./vault_migrate.sh \
+     --source-addr "https://10.44.77.172:8200" \
+     --source-cacert "/path/to/source-vault.pem" \
+     --source-token "hvs.source_token" \
+     --dest-addr "https://10.5.0.10:8200" \
+     --dest-cacert "/path/to/dest-vault.pem" \
+     --dest-token "hvs.dest_token" \
+     --mount "kv" \
+     --dry-run
+
+Script Parameters
+~~~~~~~~~~~~~~~~~
+
+**Required:**
+
+* ``--source-addr``: Source Vault address (e.g., `https://10.44.77.172:8200`)
+* ``--source-cacert``: Path to source Vault CA certificate
+* ``--source-token``: Source Vault authentication token
+* ``--dest-addr``: Destination Vault address
+* ``--dest-cacert``: Path to destination Vault CA certificate
+* ``--dest-token``: Destination Vault authentication token
+* ``--mount``: KV mount path to migrate (e.g., "kv")
+
+**Optional:**
+
+* ``--start-path``: Sub-path within the mount (e.g., "mypasswords/")
+* ``--dry-run``: Simulate the migration without making changes
+* ``--kv-version``: KV secrets engine version (default: 2)
+
+Best Practices
+--------------
+
+* **Test with a dry run**: Always use ``--dry-run`` flag first to verify the migration without making changes.
+* **Backup existing secrets**: Before migrating, consider backing up any existing secrets in the destination Vault.
+* **Verify connectivity**: Test connection to both source and destination Vaults before running the migration:
+
+  .. code-block:: bash
+
+     # Test source
+     export VAULT_ADDR=<source-addr>
+     export VAULT_CACERT=<source-cacert>
+     export VAULT_TOKEN=<source-token>
+     vault status
+
+     # Test destination
+     export VAULT_ADDR=<dest-addr>
+     export VAULT_CACERT=<dest-cacert>
+     export VAULT_TOKEN=<dest-token>
+     vault status
+
+* **Check permissions**: Ensure your Vault tokens have sufficient permissions:
+  
+  * Source token: read permissions on the mount path
+  * Destination token: write permissions and ability to enable secrets engines if needed
+
+* **Secure token handling**: Be cautious with tokens on the command line as they may be visible in process listings. Consider:
+  
+  * Using environment variables for tokens
+  * Creating short-lived tokens for migration operations
+
+* **Test incrementally**: For large migrations, test with a small subset using ``--start-path`` before migrating everything.
+* **Verify the migration**: After importing, manually verify secrets to ensure they were migrated correctly:
+
+  .. code-block:: bash
+
+     # Set destination Vault environment
+     export VAULT_ADDR=<dest-addr>
+     export VAULT_CACERT=<dest-cacert>
+     export VAULT_TOKEN=<dest-token>
+
+     # Verify a migrated secret
+     vault kv get kv/mypasswords
+
+* **Monitor the output**: The script provides detailed output showing each secret being exported and imported. Review it for warnings or errors.
+
+Troubleshooting
+---------------
+
+Script Fails to Connect to Source Vault
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you see "ERROR: Cannot connect to source Vault":
+
+* Verify ``--source-addr`` is correct and the Vault service is accessible:
+
+  .. code-block:: bash
+
+     curl -k <source-addr>/v1/sys/health
+
+* Ensure ``--source-cacert`` points to the correct certificate file
+* Check that the certificate file is readable
+* Test the connection manually:
+
+  .. code-block:: bash
+
+     export VAULT_ADDR=<source-addr>
+     export VAULT_CACERT=<source-cacert>
+     vault status
+
+Script Fails to Connect to Destination Vault
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you see "ERROR: Cannot connect to destination Vault":
+
+* Follow the same steps as for source Vault, but with destination parameters
+* Ensure the destination Vault is unsealed and accessible

--- a/misc/scripts/vault_migrate.sh
+++ b/misc/scripts/vault_migrate.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Default values
+SOURCE_ADDR=""
+SOURCE_CACERT=""
+SOURCE_TOKEN=""
+DEST_ADDR=""
+DEST_CACERT=""
+DEST_TOKEN=""
+MOUNT=""
+START_PATH=""
+DRY_RUN="false"
+KV_VERSION="2"
+
+usage() {
+    cat <<EOF
+Usage: $0 [options]
+
+Migrate secrets from source Vault to destination Vault.
+Uses vault CLI parameters directly without environment variables.
+
+Required options:
+    --source-addr ADDR         Source Vault address (e.g., https://10.44.77.172:8200)
+    --source-cacert PATH       Path to source Vault CA certificate
+    --source-token TOKEN       Source Vault authentication token
+    --dest-addr ADDR           Destination Vault address
+    --dest-cacert PATH         Path to destination Vault CA certificate
+    --dest-token TOKEN         Destination Vault authentication token
+    --mount MOUNT              KV mount path to migrate (e.g., "kv")
+
+Optional:
+    --start-path PATH          Sub-path within mount (e.g., "mypasswords/")
+    --dry-run                  Simulate migration without making changes
+    --kv-version VERSION       KV secrets engine version (default: 2)
+    --help                     Show this help message
+
+Examples:
+    # Migrate all secrets from 'kv' mount
+    $0 --source-addr https://10.44.77.172:8200 \\
+        --source-cacert ./source-vault.pem \\
+        --source-token hvs.source_token \\
+        --dest-addr https://10.5.0.10:8200 \\
+        --dest-cacert ./dest-vault.pem \\
+        --dest-token hvs.dest_token \\
+        --mount kv
+
+    # Migrate from specific path with dry-run
+    $0 --source-addr https://10.44.77.172:8200 \\
+        --source-cacert ./source-vault.pem \\
+        --source-token hvs.source_token \\
+        --dest-addr https://10.5.0.10:8200 \\
+        --dest-cacert ./dest-vault.pem \\
+        --dest-token hvs.dest_token \\
+        --mount kv \\
+        --start-path mypasswords/ \\
+        --dry-run
+EOF
+    exit 1
+}
+
+# Helper function to call vault with source credentials
+vault_source() {
+    VAULT_ADDR="$SOURCE_ADDR" VAULT_CACERT="$SOURCE_CACERT" VAULT_TOKEN="$SOURCE_TOKEN" vault "$@"
+}
+
+# Helper function to call vault with destination credentials
+vault_dest() {
+    VAULT_ADDR="$DEST_ADDR" VAULT_CACERT="$DEST_CACERT" VAULT_TOKEN="$DEST_TOKEN" vault "$@"
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --source-addr)
+            SOURCE_ADDR="$2"
+            shift 2
+            ;;
+        --source-cacert)
+            SOURCE_CACERT="$2"
+            shift 2
+            ;;
+        --source-token)
+            SOURCE_TOKEN="$2"
+            shift 2
+            ;;
+        --dest-addr)
+            DEST_ADDR="$2"
+            shift 2
+            ;;
+        --dest-cacert)
+            DEST_CACERT="$2"
+            shift 2
+            ;;
+        --dest-token)
+            DEST_TOKEN="$2"
+            shift 2
+            ;;
+        --mount)
+            MOUNT="$2"
+            shift 2
+            ;;
+        --start-path)
+            START_PATH="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN="true"
+            shift
+            ;;
+        --kv-version)
+            KV_VERSION="$2"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage
+            ;;
+    esac
+done
+
+# Validate required parameters
+if [[ -z "$SOURCE_ADDR" || -z "$SOURCE_CACERT" || -z "$SOURCE_TOKEN" ]]; then
+    echo "ERROR: --source-addr, --source-cacert, and --source-token are required" >&2
+    usage
+fi
+
+if [[ -z "$DEST_ADDR" || -z "$DEST_CACERT" || -z "$DEST_TOKEN" ]]; then
+    echo "ERROR: --dest-addr, --dest-cacert, and --dest-token are required" >&2
+    usage
+fi
+
+if [[ -z "$MOUNT" ]]; then
+    echo "ERROR: --mount is required" >&2
+    usage
+fi
+
+# Check required commands
+command -v vault >/dev/null || { echo "ERROR: vault CLI not found" >&2; exit 1; }
+command -v jq >/dev/null   || { echo "ERROR: jq not found" >&2; exit 1; }
+
+# Verify CA certificates exist
+if [[ ! -f "$SOURCE_CACERT" ]]; then
+    echo "ERROR: Source CA certificate not found: $SOURCE_CACERT" >&2
+    exit 1
+fi
+
+if [[ ! -f "$DEST_CACERT" ]]; then
+    echo "ERROR: Destination CA certificate not found: $DEST_CACERT" >&2
+    exit 1
+fi
+
+# Normalize start path: "" or ends with /
+if [[ -n "$START_PATH" && "$START_PATH" != */ ]]; then
+    START_PATH="${START_PATH}/"
+fi
+
+echo "=== Vault Secret Migration ===" >&2
+echo "Source: $SOURCE_ADDR (mount: $MOUNT, path: ${START_PATH:-/})" >&2
+echo "Destination: $DEST_ADDR (mount: $MOUNT)" >&2
+if [[ "$DRY_RUN" == "true" ]]; then
+    echo "Mode: DRY RUN (no changes will be made)" >&2
+fi
+echo "" >&2
+
+if ! vault_source status >/dev/null 2>&1; then
+    echo "ERROR: Cannot connect to source Vault at $SOURCE_ADDR" >&2
+    exit 1
+fi
+
+if ! vault_dest status >/dev/null 2>&1; then
+    echo "ERROR: Cannot connect to destination Vault at $DEST_ADDR" >&2
+    exit 1
+fi
+
+# Ensure destination mount exists
+ensure_mount() {
+    local mount="$1"
+    local key="${mount}/"
+
+    if echo "$(vault_dest secrets list -format=json)" | jq -e --arg k "$key" 'has($k)' >/dev/null; then
+        echo "Mount exists: $key" >&2
+        return 0
+    fi
+
+    echo "Mount missing, enabling KV v${KV_VERSION} at: $key" >&2
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "DRY_RUN: would enable mount at '$mount' with version '$KV_VERSION'" >&2
+        return 0
+    fi
+
+    vault_dest secrets enable -path="$mount" -version="$KV_VERSION" kv >/dev/null
+}
+
+ensure_mount "$MOUNT"
+echo "" >&2
+
+
+echo "--- Migrating secrets ---" >&2
+
+walk() {
+    local prefix="$1"   # relative path inside mount, always "" or ends with /
+
+    local keys_json
+    # Only pass prefix argument if it's not empty
+    if [[ -n "$prefix" ]]; then
+        if ! keys_json="$(vault_source kv list -format=json -mount="$MOUNT" "$prefix" 2>/dev/null)"; then
+            echo "WARN: cannot list: ${MOUNT}/${prefix}" >&2
+            return 0
+        fi
+    else
+        if ! keys_json="$(vault_source kv list -format=json -mount="$MOUNT" 2>/dev/null)"; then
+            echo "WARN: cannot list: ${MOUNT}/" >&2
+            return 0
+        fi
+    fi
+
+    echo "$keys_json" | jq -r '.[]' | while IFS= read -r k; do
+        if [[ "$k" == */ ]]; then
+            # recurse into subfolder
+            walk "${prefix}${k}"
+        else
+            local rel="${prefix}${k}"
+            echo "Migrating: ${MOUNT}/${rel}" >&2
+
+            # Get secret data from source
+            if data="$(vault_source kv get -format=json -field=data -mount="$MOUNT" "$rel" 2>/dev/null)"; then
+                if [[ "$DRY_RUN" == "true" ]]; then
+                    echo "DRY_RUN: would import to ${MOUNT}/${rel}" >&2
+                else
+                    # Write to destination
+                    if ! echo "$data" | vault_dest kv put -mount="$MOUNT" "$rel" - >/dev/null 2>&1; then
+                        echo "ERROR: failed to import ${MOUNT}/${rel}" >&2
+                    fi
+                fi
+            else
+                echo "WARN: cannot read: ${MOUNT}/${rel}" >&2
+            fi
+        fi
+    done
+}
+
+walk "$START_PATH"


### PR DESCRIPTION
This PR adds the following:
- documentation page on Vault secret migration (if those are not stored in Barbican)
- a script for exporting to a json file the secrets from the source Vault
- a script for importing to the destination Vault the secrets received via a json file