### PR TITLE
Migrate share access rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ A tool that facilitates the migration from Charmed Openstack to Sunbeam.
   the migration status for the specified plan.
   The resource dependencies could be modeled through a tree.
 * Propagate the dry run to linked resources.
-* Migrate share access rules (configurable)
 * Cross-tenant keypair and secret migrations
   * The keypairs do not have an unique ID. Cross-tenant requests must include
     the keypair name and the project/user ID, even get/list.

--- a/docs/how-to/migration-handlers/manila/share.rst
+++ b/docs/how-to/migration-handlers/manila/share.rst
@@ -2,7 +2,10 @@ Migrating Manila shares
 =======================
 
 ``sunbeam-migrate`` can be used to migrate Manila shares along with
-the share types the user data.
+the share types, access rules and user data.
+
+Migrating access rules can be disabled using the ``preserve_share_access_rules``
+setting.
 
 Share types
 -----------

--- a/sunbeam_migrate/config.py
+++ b/sunbeam_migrate/config.py
@@ -62,7 +62,9 @@ class SunbeamMigrateConfig(BaseModel):
     preserve_instance_availability_zone: bool = False
     preserve_load_balancer_availability_zone: bool = False
     # Preserve the Manila share type.
-    preserve_share_type: bool = False
+    preserve_share_type: bool = True
+    # Whether to recreate share access rules when migrating shares.
+    preserve_share_access_rules: bool = True
     # Preserve the network segmentation ID (e.g. VLAN tag or tunnel VNI).
     # This is disabled by default since it may conflict with other existing
     # networks from the destination cloud.

--- a/sunbeam_migrate/tests/integration/handlers/manila/test_share.py
+++ b/sunbeam_migrate/tests/integration/handlers/manila/test_share.py
@@ -88,3 +88,106 @@ def test_migrate_share_with_cleanup(
             ["sudo", "cat", f"{destination_mountpoint}/subdir/test_file"], text=True
         )
         assert test_file_contents == migrated_contents
+
+
+def _check_migrated_share_access_rule(source_rule, dest_rule):
+    """Check that a migrated access rule matches the source rule."""
+    fields = ["access_type", "access_to", "access_level"]
+    for field in fields:
+        source_attr = getattr(source_rule, field, None)
+        dest_attr = getattr(dest_rule, field, None)
+        assert source_attr == dest_attr, f"{field} attribute mismatch"
+
+
+def test_migrate_share_with_access_rules(
+    request,
+    test_config,
+    test_config_path,
+    test_credentials,
+    test_source_session,
+    test_destination_session,
+    test_owner_source_project,
+):
+    """Test migrating a share with access rules."""
+    # Enable access rule preservation
+    test_config.preserve_share_access_rules = True
+    test_config.preserve_share_type = True
+    with test_config_path.open("w") as f:
+        cfg_dict = json.loads(test_config.model_dump_json())
+        f.write(yaml.dump(cfg_dict))
+
+    share_type = manila_test_utils.create_test_share_type(test_source_session)
+    request.addfinalizer(
+        lambda: manila_test_utils.delete_share_type(test_source_session, share_type.id)
+    )
+
+    # Create a share
+    share = manila_test_utils.create_test_share(
+        test_source_session,
+        share_type=share_type.id,
+        size=1,
+        share_protocol="NFS",
+    )
+    request.addfinalizer(
+        lambda: manila_test_utils.delete_share(test_source_session, share.id)
+    )
+
+    # Create an access rule for IP 11.11.11.11
+    access_rule = test_source_session.shared_file_system.create_access_rule(
+        share.id,
+        access_to="11.11.11.11",
+        access_type="ip",
+        access_level="rw",
+    )
+
+    # Wait for access rule to become active
+    test_source_session.shared_file_system.wait_for_status(
+        access_rule,
+        status="active",
+        attribute="state",
+        failures=["error"],
+        interval=5,
+        wait=300,
+    )
+
+    # Refresh access rule to get latest state
+    access_rule = test_source_session.shared_file_system.get_access_rule(access_rule.id)
+
+    # Migrate the share
+    test_utils.call_migrate(
+        test_config_path,
+        [
+            "start",
+            "--resource-type=share",
+            "--include-dependencies",
+            "--cleanup-source",
+            share.id,
+        ],
+    )
+
+    dest_share_id = test_utils.get_destination_resource_id(
+        test_config_path, "share", share.id
+    )
+    request.addfinalizer(
+        lambda: manila_test_utils.delete_share(test_destination_session, dest_share_id)
+    )
+
+    dest_share = test_destination_session.shared_file_system.get_share(dest_share_id)
+    assert dest_share, "share not found on destination"
+
+    # Verify the access rule was migrated
+    dest_access_rules = list(
+        test_destination_session.shared_file_system.access_rules(dest_share)
+    )
+    dest_rule = None
+    for candidate in dest_access_rules:
+        if (
+            candidate.access_type == "ip"
+            and candidate.access_to == "11.11.11.11"
+            and candidate.access_level == "rw"
+        ):
+            dest_rule = candidate
+            break
+
+    assert dest_rule, "access rule was not migrated"
+    _check_migrated_share_access_rule(access_rule, dest_rule)


### PR DESCRIPTION
This PR will allow migrating share access rules. It can be disabled using the ``preserve_share_access_rules`` setting.