### PR TITLE
Update fip tests to allow modified fip address

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A tool that facilitates the migration from Charmed Openstack to Sunbeam.
   * We have a similar situation with Barbican secrets and secret containers,
     where we aren't normally allowed to retrieve secrets owned by other projects.
 
-## Functional tests
+## Integration tests
 
 `sunbeam_migrate/tests/integration` contains integration tests that exercise every supported
 migration handler.


### PR DESCRIPTION
We've introduced a setting that allows the destination fip address to be different than the source address (e.g. different public subnets).

We're now updating the tests to accommodate this change.