### PR TITLE
Skip identity dependencies if multitenant_mode is disabled

### DIFF
--- a/sunbeam_migrate/handlers/base.py
+++ b/sunbeam_migrate/handlers/base.py
@@ -221,6 +221,7 @@ class BaseMigrationHandler(abc.ABC):
                 "Multi-tenant mode disabled, identity resources will not "
                 "be added as dependencies."
             )
+            return
         if project_id:
             associated_resources.append(
                 Resource(resource_type="project", source_id=project_id)


### PR DESCRIPTION
Currently, we log a message that identity resources will not be added as dependencies, but we still add them, and we shouldn't.