### PR TITLE
instances: optionally preserve availability_zone as intended

### DIFF
--- a/sunbeam_migrate/handlers/nova/instance.py
+++ b/sunbeam_migrate/handlers/nova/instance.py
@@ -330,7 +330,6 @@ class InstanceHandler(base.BaseMigrationHandler):
 
         # Optional fields
         optional_fields = [
-            "availability_zone",
             "metadata",
             "user_data",
             "config_drive",


### PR DESCRIPTION
We have the config option `preserve_instance_availability_zone`, which currently has no effect, as the optional field is always set.

Fixes this issue.