### PR TITLE
Adds configurable availability zone migration for networks and routers

### DIFF
--- a/sunbeam_migrate/config.py
+++ b/sunbeam_migrate/config.py
@@ -61,6 +61,12 @@ class SunbeamMigrateConfig(BaseModel):
     preserve_volume_availability_zone: bool = False
     preserve_instance_availability_zone: bool = False
     preserve_load_balancer_availability_zone: bool = False
+    # Preserve the network availability zone hints when migrating networks.
+    # Defaults to "false" for increased compatibility.
+    preserve_network_availability_zone: bool = False
+    # Preserve the router availability zone hints when migrating routers.
+    # Defaults to "false" for increased compatibility.
+    preserve_router_availability_zone: bool = False
     # Preserve the Manila share type.
     preserve_share_type: bool = True
     # Whether to recreate share access rules when migrating shares.

--- a/sunbeam_migrate/handlers/neutron/network.py
+++ b/sunbeam_migrate/handlers/neutron/network.py
@@ -84,7 +84,6 @@ class NetworkHandler(base.BaseMigrationHandler):
             raise exception.NotFound(f"Network not found: {resource_id}")
 
         fields = [
-            "availability_zone_hints",
             "description",
             "dns_domain",
             "is_admin_state_up",
@@ -98,6 +97,8 @@ class NetworkHandler(base.BaseMigrationHandler):
             "provider_physical_network",
             "segments",
         ]
+        if CONF.preserve_network_availability_zone:
+            fields.append("availability_zone_hints")
         if CONF.preserve_network_segmentation_id:
             fields.append("provider_segmentation_id")
         kwargs = {}

--- a/sunbeam_migrate/handlers/neutron/router.py
+++ b/sunbeam_migrate/handlers/neutron/router.py
@@ -119,7 +119,6 @@ class RouterHandler(base.BaseMigrationHandler):
         )
 
         fields = [
-            "availability_zone_hints",
             "description",
             "flavor_id",
             "is_admin_state_up",
@@ -127,6 +126,8 @@ class RouterHandler(base.BaseMigrationHandler):
             "is_ha",
             "name",
         ]
+        if CONF.preserve_router_availability_zone:
+            fields.append("availability_zone_hints")
 
         kwargs = {}
         for field in fields:


### PR DESCRIPTION
Currently, we have the option to not preserve volume and instance availability zones. We can extend this to include networks and routers.