### PR TITLE
Fix readme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # openstack-migrate
 
 `openstack-migrate` facilitates the migration from Charmed Openstack to
-[Canonical OpenStack](https://canonical.com/openstack>) (Sunbeam).
+[Canonical OpenStack](https://canonical.com/openstack) (Sunbeam).
 
 The tool is designed with simplicity and versatility in mind, relying only on
 public OpenStack APIs. As such, it can migrate between different OpenStack


### PR DESCRIPTION
The readme page contains a broken Canonical Openstack link. This change drops the superflous ">" character.